### PR TITLE
Fix serialized tests

### DIFF
--- a/tl/src/test/java/com/github/badoualy/telegram/tl/api/utils/DumpUtils.java
+++ b/tl/src/test/java/com/github/badoualy/telegram/tl/api/utils/DumpUtils.java
@@ -52,7 +52,11 @@ public class DumpUtils {
     }
 
     public static <T extends TLObject> String toJson(T object) {
-        return gson.toJson(object);
+        String json = gson.toJson(object);
+        if(json.contains("\r\n"))
+            return json;
+
+        return json.replace("\n", "\r\n");
     }
 
     private static String getFilePath(Class<?> clazz) {


### PR DESCRIPTION
Test data contains json with \r\n linebreak but gson.toJson return data with \n linebreak