### PR TITLE
Add Dokka to generate Javadoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,24 @@ Then add the library dependency:
 compile 'com.github.badoualy:kotlogram:1.0.0-RC3'
 ```
 
+Javadoc
+-------
+
+You can use [Dokka](https://github.com/Kotlin/dokka) to generate a unified Javadoc-like documentation of the Kotlin and Java classes:
+
+~~~bash
+./gradlew dokka
+~~~
+
+This might take a while (up to an hour) because of the large number of source files in the [tl](https://github.com/badoualy/kotlogram/tree/master/tl) module.
+
+The documentation will be placed separately for each module in the following directories:
+
+- `api/build/javadoc`
+- `mtproto/build/javadoc`
+- `tl/build/javadoc`
+- `tl-builder/build/javadoc`
+
 Licence
 ----------------
 ```

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -23,3 +23,10 @@ task fatJar(type: Jar) {
     from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
     with jar
 }
+
+apply plugin: 'org.jetbrains.dokka'
+
+dokka {
+    outputFormat = 'javadoc'
+    outputDirectory = "$buildDir/javadoc"
+}

--- a/build.gradle
+++ b/build.gradle
@@ -18,11 +18,14 @@ subprojects {
 
     buildscript {
         ext.kotlin_version = '1.1.2-5'
+        ext.dokka_version = '0.9.16'
         repositories {
+            jcenter()
             mavenCentral()
         }
         dependencies {
             classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+            classpath "org.jetbrains.dokka:dokka-gradle-plugin:$dokka_version"
         }
     }
 

--- a/mtproto/build.gradle
+++ b/mtproto/build.gradle
@@ -31,3 +31,10 @@ task fatJar(type: Jar) {
     from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
     with jar
 }
+
+apply plugin: 'org.jetbrains.dokka'
+
+dokka {
+    outputFormat = 'javadoc'
+    outputDirectory = "$buildDir/javadoc"
+}

--- a/tl-builder/build.gradle
+++ b/tl-builder/build.gradle
@@ -27,3 +27,10 @@ dependencies {
     from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
     with jar
 }*/
+
+apply plugin: 'org.jetbrains.dokka'
+
+dokka {
+    outputFormat = 'javadoc'
+    outputDirectory = "$buildDir/javadoc"
+}

--- a/tl/build.gradle
+++ b/tl/build.gradle
@@ -38,3 +38,10 @@ task fatJar(type: Jar) {
     from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
     with jar
 }
+
+apply plugin: 'org.jetbrains.dokka'
+
+dokka {
+    outputFormat = 'javadoc'
+    outputDirectory = "$buildDir/javadoc"
+}


### PR DESCRIPTION
The documentation on https://kotlogram.readme.io/ is very good, but what's missing are the Javadocs of all the classes.

I added [Dokka](https://github.com/Kotlin/dokka) in the main and module Gradle build files which allows to create a common Javadoc documentation for both the Kotlin and Java source files.